### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,16 +10,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Ruby version specified in `.ruby-version`
+      - name: Remove Gemfile.lock
+        run: |
+          rm Gemfile.lock
+      - name: Set up Ruby 
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-        uses: eregon/use-ruby-action@master
-      - name: Install dependencies
-        run: bundle install --jobs 4 --retry 3
+          bundler-cache: true
       - name: Run tests with RSpec
         run: bundle exec rspec
       - name: Run Rubocop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby version specified in `.ruby-version`
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/spec/app/controllers/healthcheck/healthchecks_controller_spec.rb
+++ b/spec/app/controllers/healthcheck/healthchecks_controller_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe Healthcheck::HealthchecksController, type: :model do
         it 'returns verbose response' do
           expect(controller)
             .to receive(:render)
-            .with(
-              status: Healthcheck.configuration.success,
-              json: {
-                code: Healthcheck.configuration.success,
-                status: { zero_division: 'OK' }
-              }
-            )
+            .with({
+                    status: Healthcheck.configuration.success,
+                    json: {
+                      code: Healthcheck.configuration.success,
+                      status: { zero_division: 'OK' }
+                    }
+                  })
             .once
         end
       end
@@ -56,19 +56,19 @@ RSpec.describe Healthcheck::HealthchecksController, type: :model do
         it 'returns verbose response' do
           expect(controller)
             .to receive(:render)
-            .with(
-              json: {
-                code: Healthcheck.configuration.error,
-                errors: [
-                  {
-                    'exception' => 'ZeroDivisionError',
-                    'message' => 'divided by 0',
-                    'name' => 'zero_division'
-                  }
-                ]
-              },
-              status: Healthcheck.configuration.error
-            )
+            .with({
+                    json: {
+                      code: Healthcheck.configuration.error,
+                      errors: [
+                        {
+                          'exception' => 'ZeroDivisionError',
+                          'message' => 'divided by 0',
+                          'name' => 'zero_division'
+                        }
+                      ]
+                    },
+                    status: Healthcheck.configuration.error
+                  })
             .once
         end
       end

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/spec/dummy/config/puma.rb
+++ b/spec/dummy/config/puma.rb
@@ -6,20 +6,20 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
 min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch('PORT') { 3000 }
+port        ENV.fetch('PORT', 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch('RAILS_ENV') { 'development' }
+environment ENV.fetch('RAILS_ENV', 'development')
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
+pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ require 'healthcheck'
 require './app/controllers/healthcheck/healthchecks_controller'
 
 require File.expand_path('../spec/dummy/config/environment.rb', __dir__)
-ENV['RAILS_ROOT'] ||= File.dirname(__FILE__) + '../../../spec/dummy'
+ENV['RAILS_ROOT'] ||= "#{File.dirname(__FILE__)}../../../spec/dummy"
 
 require 'rspec/rails'
 require 'timecop'


### PR DESCRIPTION
To get this green I:

1. Added a few explicit `{` and `}` to arguments, to properly distinguish between hash arguments and positional arguments
2. Addressed a few Rubocop lints
3. Switched to the standard Ruby action
4. Deleted the Gemfile.lock during CI, allowing bundler to rebuild it with the appropriate Ruby.
5. Switched to using `bundler-cache` from the ruby/setup-ruby action

Also upgraded the checkout action version.

Runs green on my fork.