### PR TITLE
Make health check autodetectable.

### DIFF
--- a/lib/generators/healthcheck/install_generator.rb
+++ b/lib/generators/healthcheck/install_generator.rb
@@ -33,6 +33,7 @@ module Healthcheck
         HEALTHCHECK_INITIALIZER_TEXT
       )
       route 'Healthcheck.routes(self)'
+      comment_lines 'config/routes.rb', /:rails_health_check/
     end
   end
 end

--- a/lib/healthcheck/router.rb
+++ b/lib/healthcheck/router.rb
@@ -5,7 +5,8 @@ module Healthcheck
     def self.mount(router)
       router.send(
         Healthcheck.configuration.method,
-        Healthcheck.configuration.route => 'healthcheck/healthchecks#check'
+        Healthcheck.configuration.route => 'healthcheck/healthchecks#check',
+        as: :rails_health_check
       )
     end
   end


### PR DESCRIPTION
Background: Rails 7.1 will be adding health checks.  I work for Fly.io as a Rails Speciality and would like to make Fly.io automatically detect the presence of health checks and pre-configure applications to enable these health checks if I can detect them.  The problem is that health checks can vary on paths and implementation, so I'm proposing the following way to detect checks:

```
bin/rails runner "p Rails.application.routes.url_helpers.rails_health_check_path"
```

This pull request will add `as: :rails_healh_check` to the route.  Additionally the generator will comment out any Rails 7.1 health check that might be present.

See also:
* https://github.com/superfly/flyctl/pull/1678
* https://github.com/rails/rails/pull/47217
* https://github.com/rails/rails/pull/46936